### PR TITLE
Feat : 엔티티 수정

### DIFF
--- a/src/main/java/com/moadream/giftogether/bank/model/Bank.java
+++ b/src/main/java/com/moadream/giftogether/bank/model/Bank.java
@@ -2,6 +2,7 @@ package com.moadream.giftogether.bank.model;
 
 import java.time.LocalDateTime;
 
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
 
 import jakarta.persistence.Column;
@@ -21,7 +22,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "T_Bank")
-public class Bank {
+public class Bank extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,10 +35,6 @@ public class Bank {
     
     @Column(nullable = false)
     private Integer deposit;
-    
-    private LocalDateTime createAt; 
-
-    private LocalDateTime updateAt;    
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/moadream/giftogether/bank/model/Bank.java
+++ b/src/main/java/com/moadream/giftogether/bank/model/Bank.java
@@ -1,21 +1,11 @@
 package com.moadream.giftogether.bank.model;
 
-import java.time.LocalDateTime;
-
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-
 
 
 @Getter
@@ -27,18 +17,18 @@ public class Bank extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 30)
-    private String bankname;
-    
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 50)
+    private String bankName;
+
+    @Column(nullable = false, length = 50)
     private String account;
-    
+
     @Column(nullable = false)
     private Integer deposit;
 
     @ManyToOne
     @JoinColumn(name = "member_id")
- 	private Member member; 
+    private Member member;
 
-    
+
 }

--- a/src/main/java/com/moadream/giftogether/funding/model/Funding.java
+++ b/src/main/java/com/moadream/giftogether/funding/model/Funding.java
@@ -3,6 +3,7 @@ package com.moadream.giftogether.funding.model;
 import java.time.LocalDateTime;
 
 import com.moadream.giftogether.Status;
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
 import com.moadream.giftogether.message.model.Message;
 import com.moadream.giftogether.product.model.Product;
@@ -27,7 +28,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "T_Funding")
-public class Funding {
+public class Funding extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,15 +41,9 @@ public class Funding {
 	@Enumerated(EnumType.STRING)
 	private Status status;
 
-    private LocalDateTime createAt; 
-
-    private LocalDateTime updateAt;
-
-    
     @OneToOne(mappedBy = "funding") 
     private Message message; 
-    
-    
+
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member; 

--- a/src/main/java/com/moadream/giftogether/funding/model/Funding.java
+++ b/src/main/java/com/moadream/giftogether/funding/model/Funding.java
@@ -1,27 +1,13 @@
 package com.moadream.giftogether.funding.model;
 
-import java.time.LocalDateTime;
-
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
 import com.moadream.giftogether.message.model.Message;
 import com.moadream.giftogether.product.model.Product;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-
 
 
 @Getter
@@ -33,23 +19,22 @@ public class Funding extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    
     @Column(nullable = false)
     private Integer amount;
-    
-	@Column(nullable=false)
-	@Enumerated(EnumType.STRING)
-	private Status status;
 
-    @OneToOne(mappedBy = "funding") 
-    private Message message; 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToOne(mappedBy = "funding")
+    private Message message;
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private Member member; 
-    
+    private Member member;
+
     @ManyToOne
     @JoinColumn(name = "product_id")
-    private Product product;  
-    
+    private Product product;
+
 }

--- a/src/main/java/com/moadream/giftogether/global/audit/BaseTimeEntity.java
+++ b/src/main/java/com/moadream/giftogether/global/audit/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.moadream.giftogether.global.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/moadream/giftogether/member/model/Member.java
+++ b/src/main/java/com/moadream/giftogether/member/model/Member.java
@@ -1,27 +1,17 @@
 package com.moadream.giftogether.member.model;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.bank.model.Bank;
 import com.moadream.giftogether.funding.model.Funding;
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 
 @Getter
@@ -29,44 +19,42 @@ import lombok.Setter;
 @Entity
 @Table(name = "T_Member")
 public class Member extends BaseTimeEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	
-	@Column(length=30, nullable=false)
-	private String username;// 실명
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(length=30,nullable=false)
-	private String nickname;
-	
-	// 이미지 처리 
-	private String profile;
-	
-	private Date birth;
-	
+    //설명
+    @Column(length = 30, nullable = false)
+    private String username;
 
-	@Column(unique=true, length=30)
-	private String phoneNumber;
-	
-	@Column(length=255)
-	private String address;
-	
-	
-	@Column(nullable=false)
-	@Enumerated(EnumType.STRING)
-	private Role role;
-	
-	@Column(nullable=false)
-	@Enumerated(EnumType.STRING)
-	private Status status;
+    @Column(length = 30, nullable = false)
+    private String nickname;
 
-	@OneToMany(mappedBy="member")
-	private List<Funding> fundingLists= new ArrayList<>();
-	
-	@OneToMany(mappedBy="member")
-	private List<WishList> wishLists = new ArrayList<>();
-	
-	@OneToMany(mappedBy ="member")
-	private List<Bank> bankLists = new ArrayList<>();
+    // 이미지 처리
+    private String profile;
+
+    private Date birth;
+
+    @Column(unique = true, length = 50)
+    private String phoneNumber;
+
+    private String address;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToMany(mappedBy = "member")
+    private List<Funding> fundingLists = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<WishList> wishLists = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Bank> bankLists = new ArrayList<>();
 
 }

--- a/src/main/java/com/moadream/giftogether/member/model/Member.java
+++ b/src/main/java/com/moadream/giftogether/member/model/Member.java
@@ -8,6 +8,7 @@ import java.util.List;
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.bank.model.Bank;
 import com.moadream.giftogether.funding.model.Funding;
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
 
 import jakarta.persistence.Column;
@@ -27,14 +28,13 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "T_Member")
-public class Member {
+public class Member extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
 	@Column(length=30, nullable=false)
 	private String username;// 실명
-	
 
 	@Column(length=30,nullable=false)
 	private String nickname;
@@ -59,13 +59,7 @@ public class Member {
 	@Column(nullable=false)
 	@Enumerated(EnumType.STRING)
 	private Status status;
-	
 
-	private LocalDateTime createdAt;
-	
-
-	private LocalDateTime updatedAt;
-	
 	@OneToMany(mappedBy="member")
 	private List<Funding> fundingLists= new ArrayList<>();
 	

--- a/src/main/java/com/moadream/giftogether/message/model/Message.java
+++ b/src/main/java/com/moadream/giftogether/message/model/Message.java
@@ -1,28 +1,10 @@
 package com.moadream.giftogether.message.model;
 
-import java.time.LocalDateTime;
-//
-//import com.moadream.giftogether.funding.Funding;
-//import com.moadream.giftogether.wishList.Wishlist;
-
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.funding.model.Funding;
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -36,12 +18,11 @@ public class Message extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "content", nullable = true)
     private String content;
 
-	@Column(nullable=false)
-	@Enumerated(EnumType.STRING)
-	private Status status;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @ManyToOne
     @JoinColumn(name = "wishlist_id", nullable = false)
@@ -50,6 +31,6 @@ public class Message extends BaseTimeEntity {
     @OneToOne
     @JoinColumn(name = "funding_id", nullable = false)
     private Funding funding;
-    
+
     // Getters and Setters
 }

--- a/src/main/java/com/moadream/giftogether/message/model/Message.java
+++ b/src/main/java/com/moadream/giftogether/message/model/Message.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.funding.model.Funding;
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
 
 import jakarta.persistence.Column;
@@ -29,7 +30,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "T_Message")
-public class Message {
+public class Message extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,15 +43,6 @@ public class Message {
 	@Enumerated(EnumType.STRING)
 	private Status status;
 
-    @Column(name = "created_at", nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createAt;
-
-    @Column(name = "updated_at", nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updateAt;
-
-    
     @ManyToOne
     @JoinColumn(name = "wishlist_id", nullable = false)
     private WishList wishlist;

--- a/src/main/java/com/moadream/giftogether/product/model/Product.java
+++ b/src/main/java/com/moadream/giftogether/product/model/Product.java
@@ -1,33 +1,17 @@
 package com.moadream.giftogether.product.model;
- 
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.funding.model.Funding;
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
-
-//import com.moadream.giftogether.wishList.Wishlist;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -39,41 +23,36 @@ public class Product extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
-    @Column(name = "name", length = 30)
+
+    @Column(length = 30)
     private String name;
-    
-    @Column(name = "description", length = 255)
+
     private String description;
-    
-    @Column(name = "link", length = 255)
-    private String link;
-    
-    @Column(name = "externa_link", length = 255)
-    private String externaLlink;
-    
-    @Column(name = "product_img", length = 255)
+
+    private String productLink;
+
+    private String externalLink;
+
     private String productImg;
-    
-    @Column(name = "option_detail", length = 120, nullable = true)
+
+    @Column(length = 120)
     private String optionDetail;
-    
-	@Column(nullable=false)
-	@Enumerated(EnumType.STRING)
-	private Status status;
-    
-    @Column(name = "current_amount", nullable = false)
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(nullable = false)
     private int currentAmount;
-    
-    @Column(name = "goal_amount", nullable = false)
+
+    @Column(nullable = false)
     private int goalAmount;
 
-	@ManyToOne
-	@JoinColumn(name = "wishlist_id")
-	private WishList wishlist; // FK
-	// Getters and Setters
-	
-	@OneToMany(mappedBy = "product")
-	private List<Funding> FundingList = new ArrayList<>();
+    @ManyToOne
+    @JoinColumn(name = "wishlist_id")
+    private WishList wishlist;
+
+    @OneToMany(mappedBy = "product")
+    private List<Funding> FundingList = new ArrayList<>();
 
 }

--- a/src/main/java/com/moadream/giftogether/product/model/Product.java
+++ b/src/main/java/com/moadream/giftogether/product/model/Product.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.funding.model.Funding;
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.wishlist.model.WishList;
 
 //import com.moadream.giftogether.wishList.Wishlist;
@@ -33,7 +34,7 @@ import lombok.ToString;
 @Entity
 @ToString
 @Table(name = "T_Product")
-public class Product {
+public class Product extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -67,14 +68,6 @@ public class Product {
     @Column(name = "goal_amount", nullable = false)
     private int goalAmount;
 
-    @Column(name = "created_at", nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createAt;
-
-    @Column(name = "updated_at", nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updateAt;
-    
 	@ManyToOne
 	@JoinColumn(name = "wishlist_id")
 	private WishList wishlist; // FK

--- a/src/main/java/com/moadream/giftogether/wishlist/model/WishList.java
+++ b/src/main/java/com/moadream/giftogether/wishlist/model/WishList.java
@@ -1,55 +1,45 @@
 package com.moadream.giftogether.wishlist.model;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.moadream.giftogether.Status;
 import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
 import com.moadream.giftogether.message.model.Message;
 import com.moadream.giftogether.product.model.Product;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "T_WishList")
 public class WishList extends BaseTimeEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, length = 255)
+	@Column(nullable = false)
 	private String link;
 
 	@Column(nullable = false, length = 30)
 	private String name;
 
-	@Column(nullable = false, length = 255)
+	@Column(nullable = false)
 	private String description;
 
-	@Column(nullable = false, length = 255)
-	private String listimg;
+	@Column(nullable = false)
+	private String listImg;
 
-	@Column(nullable = false, length = 255)
+	@Column(nullable = false)
 	private String address;
 
 	@Column(nullable = false, length = 30)
-	private String phonenumber;
+	private String phoneNumber;
 
 	private LocalDateTime deadline;
 

--- a/src/main/java/com/moadream/giftogether/wishlist/model/WishList.java
+++ b/src/main/java/com/moadream/giftogether/wishlist/model/WishList.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.moadream.giftogether.Status;
+import com.moadream.giftogether.global.audit.BaseTimeEntity;
 import com.moadream.giftogether.member.model.Member;
 import com.moadream.giftogether.message.model.Message;
 import com.moadream.giftogether.product.model.Product;
@@ -27,7 +28,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "T_WishList")
-public class WishList {
+public class WishList extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -55,10 +56,6 @@ public class WishList {
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private Status status;
-
-	private LocalDateTime createAt;
-
-	private LocalDateTime updateAt;
 
 	@OneToMany(mappedBy = "wishlist")
 	private List<Message> MessagesList = new ArrayList<>();

--- a/src/main/resources/application-main.properties
+++ b/src/main/resources/application-main.properties
@@ -10,7 +10,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.OracleDialect
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
 spring.jpa.properties.hibernate.auto_quote_keyword=true
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 
 # Hibernate SQL
 spring.jpa.show-sql=false


### PR DESCRIPTION
## 🙆‍♂️ Issue

#8 

## 📝 Description

추가된 코드에요

- BaseTimeEntity 생성
![1](https://github.com/MoAaDream/Giftogether/assets/87762815/df96171c-8720-4cbd-9124-852fd9f67429)
BaseTimeEntity 추상 클래스를 구현하였어요
해당 클래스에 공통으로 사용하는 컬럼을 만들어 모든 엔티티에 적용하여 중복되는 코드를 줄였어요


- ddl auto 변경
![5](https://github.com/MoAaDream/Giftogether/assets/87762815/8131dc0a-b542-43d5-8b9a-9a17a80d2913)
ddl-auto를 create에서 update로 변경함에 따라 실행 될 때 테이블이 삭제되고 실행되는 것이 아닌 존재하는 테이블에서 컬럼이나 속성이 변경되는 것만 업데이트 해줘요


다음에 나오는 글들은 수정된 코드에요


- length의 디폴트 길이 255
![2](https://github.com/MoAaDream/Giftogether/assets/87762815/65aac683-29ef-4990-9dcc-0ce39fe7ede1)
Column의 length 속성은 최대가 255이며 만약 설정하지 않으면 디폴트값이 255이며 length=255는 불필요한 코드라 삭제하였어요

- nullable 디폴트 값 true
![3](https://github.com/MoAaDream/Giftogether/assets/87762815/500d603a-98f2-4288-a415-b6c8059fe75b)
또한 nullable은 설정하지 않으면 디폴트값이 true이므로 불필요한 코드라 삭제하였어요

- JPA의 스네이크케이스 변환
![4](https://github.com/MoAaDream/Giftogether/assets/87762815/32810f16-7ba7-4027-adae-7b7f714d663f)
JPA는 카멜케이스를 스네이크 케이스로 변환시켜주기 때문에 카멜케이스만 제대로 적으면 알아서 스네이트 케이스로 바꿔주며 Column 어노테이션에서 name 속성을 쓸 필요가 없어요

예를 들어 optionalDetail은 JPA가 알아서 optional_detail로 변환시켜줘요

마지막으로 단어가 2개 이상 합쳐진 것은 카멜케이스로 변경하였어요


## ✨ Feature

- BaseTimeEntity 구현
- ddl-auto update로 변경
- 불필요한 코드 삭제 및 import문 최적화

## 👌 Review Change

This closes #8 